### PR TITLE
MBS-8117: fix draghomes height to prevent overflow

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -15,12 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Privacy Subsystem implementation for format_tabtopics.
+ * Privacy Subsystem implementation for qtype_ddmatch.
  *
  * @package    qtype_ddmatch
- * 
  * @author DualCube <admin@dualcube.com>
- * @copyright  2007 DualCube (https://dualcube.com) 
+ * @copyright  2007 DualCube (https://dualcube.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -29,19 +28,25 @@ namespace qtype_ddmatch\privacy;
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * The format_tabtopics
+ * Privacy main class.
+ *
+ * @package    qtype_ddmatch
+ * @copyright  2019 Amr Hourani <amr.hourani@let.ethz.ch>, 2021 Thomas Ludwig, ISB
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  */
-class provider implements \core_privacy\local\metadata\null_provider
-{
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    // To provide php 5.6 (33_STABLE) and up support.
+    use \core_privacy\local\legacy_polyfill;
+
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return string
      */
-    public static function get_reason(): string
-    {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }

--- a/lang/en/qtype_ddmatch.php
+++ b/lang/en/qtype_ddmatch.php
@@ -19,9 +19,9 @@
  * The language strings for the match question type.
  *
  * @package    qtype_ddmatch
- * 
+ *
  * @author DualCube <admin@dualcube.com>
- * @copyright  2007 DualCube (https://dualcube.com) 
+ * @copyright  2007 DualCube (https://dualcube.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/styles.css
+++ b/styles.css
@@ -67,7 +67,7 @@ li.matchdrag.copy {
     margin: 0;
     padding: 0.25rem;
     width: 35%;
-    max-height:23.75rem;
+    max-height: fit-content;
 }
 
 .ddmatch .draghomes li {

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -19,9 +19,9 @@
  *
  * @package    qtype
  * @subpackage ddmatch
- * 
+ *
  * @author DualCube <admin@dualcube.com>
- * @copyright  2007 DualCube (https://dualcube.com) 
+ * @copyright  2007 DualCube (https://dualcube.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -149,7 +149,7 @@ class question_test extends advanced_testcase {
             $this->assertMatchesRegularExpression('/' . preg_quote($stem, '/') . '/', $qsummary);
         }
         foreach ($ddmatch->choices as $choice) {
-            $this->assertRegExp('/' . preg_quote($choice) . '/', $qsummary);
+            $this->assertMatchesRegularExpression('/' . preg_quote($choice) . '/', $qsummary);
         }
     }
 


### PR DESCRIPTION
For many items, these extend beyond the question area. See screenshot.


![ddmtach_boost](https://github.com/mebis-lp/moodle-qtype_ddmatch/assets/89569104/7a456a9e-81f7-4b64-b7ca-32d920110b9f)

This can be prevented by not setting the height of the area.